### PR TITLE
Upload v0.3.1

### DIFF
--- a/Aircraft/FBW/A32NX/PythonFO.py
+++ b/Aircraft/FBW/A32NX/PythonFO.py
@@ -5,18 +5,25 @@
 
 import sys
 import os
-sys.path.insert(1, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../../..")))
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../code")))
 
 from utils import debug, ptt_key
 import keyboard
 from listen_for_command import listen_for_command
+from process_command import process_command
 from time import sleep
 
 def main():
     print("Press " + ptt_key + " to talk.")
     while True:
         if keyboard.is_pressed(ptt_key):
-            listen_for_command()
+            command = listen_for_command()
+            if command == "error":
+                continue
+            else:
+                process_command(command)
+
         sleep(0.1)
 
 def license_notice():

--- a/Aircraft/FBW/A32NX/list_of_commands.md
+++ b/Aircraft/FBW/A32NX/list_of_commands.md
@@ -1,0 +1,3 @@
+* flaps up, 1, 2, 3, 4 (full, down)
+* heading 0-359 (example: "heading two-six-four", "heading zero-one-nine")
+* frequency 118.000-136.990 (example: "frequency one-two-two decimal eight", "frequency one-two-two-eight")

--- a/Aircraft/FBW/A32NX/process_command.py
+++ b/Aircraft/FBW/A32NX/process_command.py
@@ -5,7 +5,7 @@
 
 import sys
 import os
-sys.path.insert(1, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../../..")))
 
 import utils
 import sc_functions
@@ -71,8 +71,7 @@ def process_flaps(command_value):
 def process_heading(command_value):
     try:
         heading_int = int(command_value)
-        if heading_int < 360:
-            heading_int = f"{heading_int:03d}"
+        if heading_int < 360 and len(command_value) == 3:
             if utils.debug:
                 print("DEBUG: process_command.process_heading.heading_int == " + str(heading_int))
             sc_functions.heading(heading_int)
@@ -85,6 +84,8 @@ def process_heading(command_value):
 def process_frequency(command_value):
     frequency_str = str(command_value).replace("decimal", "").strip()
     frequency_str = str(frequency_str).replace(".", "").strip()
+    frequency_str = str(frequency_str).replace(",", "").strip()
+    frequency_str = str(frequency_str).replace(" ", "").strip()
     frequency_int = int(frequency_str)
 
     if 118 <= frequency_int <= 136990 and len(frequency_str) <= 6:

--- a/Aircraft/FBW/A32NX/sc_functions.py
+++ b/Aircraft/FBW/A32NX/sc_functions.py
@@ -5,7 +5,7 @@
 
 import sys
 import os
-sys.path.insert(1, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../../..")))
 
 from utils import debug
 from simconnect import SimConnect

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,13 @@
-# New features in 0.3.0
-* You can now set a default command in utils.py. If no prefix is added when you say your command, the program will interpret it as the default command. This is useful for commands that you use frequently.
+# New features in 0.3.1
+* Whisper's requirements are now separated from the main requirements, so you can install them only if you want to use Whisper.
 
-# Technical changes in 0.3.0
-* process_command() now removes the specific prefix (flaps/heading/frequency) before sending it to the appropriate processing function. This should increase reliability and enable for more complex processing functions.
+# Bug fixes in 0.3.1
+* Frequency commands did not work if "decimal" was in the command.
 
-# Licensing changes in 0.3.0
-* PythonFO description changed from: "voice control for Microsoft Flight Simulator written entirely in Python" to "Free virtual first officer for Microsoft Flight Simulator written entirely in Python"
+# Other changes in 0.3.1
+* Zero padding for headings is now removed, because different users might want to add zeroes before or after the commanded numbers.
+* The default ptt key is now `alt`.
+* Every aircraft now as its own `list_of_commands.md` in its folder.
+
+# Technical changes in 0.3.1
+* `listen_for_commands.py` is now separated from the aircraft-specific code, because the same speech recognition code can be used regardless of aircraft. This should make it easier to add more supported aircraft.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# PythonFO v0.3.0-alpha
+# PythonFO v0.3.1-alpha
 
 **Copyright (C) 2025  Vilgot Szasz Kero
 PythonFO comes with ABSOLUTELY NO WARRANTY; for details see COPYRIGHT.txt**
@@ -9,13 +9,13 @@ PythonFO comes with ABSOLUTELY NO WARRANTY; for details see COPYRIGHT.txt**
 
 ## Introduction
 
-This is a free, open-source virtual first officer for Microsoft Flight Simulator written entirely in Python. It uses SpeechRecognition (select API in utils.py) to transcribe commands, and pysimconnect to send data to the simulator.
+This is a free, open-source virtual first officer for Microsoft Flight Simulator written entirely in Python. It uses SpeechRecognition (see **Supported speech recognition APIs** below) to transcribe commands, and pysimconnect to send data to the simulator.
 
 *This is a personal project*, so it is obviously very limited compared to paid services. You also need to manually install the required packages (`pip install -r requirements.txt`) and run the script with your local Python.
 
 ## Requirements:
 
-* Python (tested on 3.13.2) + requirements.txt
+* Python (tested on 3.13.2) + requirements.txt + requirements_[optional feature].txt
 
 ## Supported simulators (tested on):
 
@@ -25,14 +25,12 @@ This is a free, open-source virtual first officer for Microsoft Flight Simulator
 
 * FlyByWire A32NX
 
+## Supported speech recognition APIs:
+* `google`: fast and light but less accurate, no additional requirements
+* `whisper`: very slow and heavy but more accurate, requires `requirements_whisper.txt`
+
 ## Usage
 
 1. Set your preferences in `utils.py`
 2. Run `PythonFO.py`
-3. Press `shift` (no need to hold it down) and say your command (see **list of commands** below)
-
-## List of commands
-
-* flaps up, 1, 2, 3, 4 (full, down)
-* heading 0-359 (example: "heading three-six-five", "heading one-nine")
-* frequency 118.000-136.990 (example: "frequency one-two-two decimal eight", "frequency one-two-two-eight")
+3. Press the ptt key that you set in `utils.py` (no need to hold it down) and say your command (see `list_of_commands.md` for each aircraft)

--- a/code/listen_for_command.py
+++ b/code/listen_for_command.py
@@ -5,7 +5,7 @@
 
 import sys
 import os
-sys.path.insert(1, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from utils import recognizer_api
 if recognizer_api == "whisper":
@@ -17,8 +17,6 @@ import speech_recognition as sr
 recognizer = sr.Recognizer()
 mic = sr.Microphone()
 
-from process_command import process_command
-
 
 def listen_for_command():
     with mic as source:
@@ -27,15 +25,15 @@ def listen_for_command():
         audio = recognizer.listen(source)
 
     try:
-        if recognizer_api == "whisper":
+        if recognizer_api == "google":
             print("Recognizing...")
-            command = recognizer.recognize_whisper(audio, model=whisper_model)
+            command = recognizer.recognize_google(audio)
             if command is None:
                 raise ValueError("Recognzer returned None")
 
-        elif recognizer_api == "google":
+        elif recognizer_api == "whisper":
             print("Recognizing...")
-            command = recognizer.recognize_google(audio)
+            command = recognizer.recognize_whisper(audio, model=whisper_model)
             if command is None:
                 raise ValueError("Recognzer returned None")
 
@@ -55,9 +53,11 @@ def listen_for_command():
             command = command.replace("/", "")
         
         print(f"Recognized: {command}")
-        process_command(command)
+        return command
     
     except sr.UnknownValueError:
         print("Could not understand the command.")
+        return "error"
     except sr.RequestError:
         print("Could not request results.")
+        return "error"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ build-backend = "setuptools.build_meta"
 name = "PythonFO"
 description = "Free virtual first officer for Microsoft Flight Simulator written entirely in Python"
 keywords = ["Microsoft Flight Simulator", "MSFS", "voice control"]
-version = "0.3.0"
+version = "0.3.1"
 
 readme = "README.md"
 license = "GPL-3.0-or-later"
@@ -25,10 +25,16 @@ dependencies = [
     "keyboard",
     "pyaudio",
     "SpeechRecognition",
-    "git+https://github.com/openai/whisper.git",
-    "soundfile",
     "pysimconnect"
 ]
+
+
+[project.optional-dependencies]
+whisper = [
+    "git+https://github.com/openai/whisper.git",
+    "soundfile"
+    ]
+
 
 classifiers = [
     "Programming Language :: Python",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,4 @@
 keyboard
 pyaudio
 SpeechRecognition
-git+https://github.com/openai/whisper.git
-soundfile
 pysimconnect

--- a/requirements_whisper.txt
+++ b/requirements_whisper.txt
@@ -1,0 +1,2 @@
+git+https://github.com/openai/whisper.git
+soundfile

--- a/utils.py
+++ b/utils.py
@@ -4,12 +4,12 @@
 
 
 # General settings
-ptt_key = "shift"
+ptt_key = "alt"
 enable_default_command = False # If True, the default command will be executed if no command prefix is recognized
 default_command = "frequency"
 
 # Speech recognition settings
-recognizer_api = "google" # google: fast and light but less accurate, whisper: slow and heavy but more accurate
+recognizer_api = "google" # see "Supported speech recognition APIs" in "README.md"
 whisper_model = "turbo"
 
 # Developer mode


### PR DESCRIPTION
# New features in 0.3.1
* Whisper's requirements are now separated from the main requirements, so you can install them only if you want to use Whisper.

# Bug fixes in 0.3.1
* Frequency commands did not work if "decimal" was in the command.

# Other changes in 0.3.1
* Zero padding for headings is now removed, because different users might want to add zeroes before or after the commanded numbers.
* The default ptt key is now `alt`.
* Every aircraft now as its own `list_of_commands.md` in its folder.

# Technical changes in 0.3.1
* `listen_for_commands.py` is now separated from the aircraft-specific code, because the same speech recognition code can be used regardless of aircraft. This should make it easier to add more supported aircraft.